### PR TITLE
refine counter transfer closing

### DIFF
--- a/saleor/api/order/payload/create_order.json
+++ b/saleor/api/order/payload/create_order.json
@@ -31,5 +31,5 @@
     "status": "payment-pending",
     "total_tax": "0.00",
     "discount_amount": "0.00",
-    "old_orders": null
+    "old_orders": []
 }

--- a/saleor/counter/api/serializers.py
+++ b/saleor/counter/api/serializers.py
@@ -8,12 +8,14 @@ class TableListSerializer(serializers.ModelSerializer):
     update_url = serializers.HyperlinkedIdentityField(view_name='counter:api-update')
     delete_url = serializers.HyperlinkedIdentityField(view_name='counter:api-delete')
     text = serializers.SerializerMethodField()
+    is_closed = serializers.SerializerMethodField()
 
     class Meta:
         model = Table
         fields = ('id',
                   'name',
                   'text',
+                  'is_closed',
                   'description',
                   'update_url',
                   'delete_url'
@@ -24,6 +26,9 @@ class TableListSerializer(serializers.ModelSerializer):
             return obj.name
         except:
             return ''
+
+    def get_is_closed(self, obj):
+        return obj.is_closed()
 
 
 class CreateListSerializer(serializers.ModelSerializer):

--- a/saleor/counter/api/views.py
+++ b/saleor/counter/api/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework import pagination
 from .pagination import PostLimitOffsetPagination
-
+import datetime
 from saleor.counter.models import Counter as Table
 from .serializers import (
     CreateListSerializer,

--- a/saleor/countertransfer/api/views.py
+++ b/saleor/countertransfer/api/views.py
@@ -9,6 +9,7 @@ from saleor.countertransfer.models import CounterTransfer as Table
 from saleor.product.models import Stock
 from saleor.countertransfer.models import CounterTransferItems as Item
 from .serializers import (
+    CloseTransferItemSerializer,
     CreateListSerializer,
     TableListSerializer,
     UpdateSerializer,
@@ -253,3 +254,16 @@ class UpdateItemAPIView(generics.RetrieveUpdateAPIView):
     """
     queryset = Item.objects.all()
     serializer_class = UpdateTransferItemSerializer
+
+
+class CloseItemAPIView(generics.RetrieveUpdateAPIView):
+    """
+        update instance details
+        @:param pk id
+        @:method PUT
+
+        PUT /api/house/update/
+        payload Json: /payload/update.json
+    """
+    queryset = Item.objects.all()
+    serializer_class = CloseTransferItemSerializer

--- a/saleor/countertransfer/templates/countertransfer/form.html
+++ b/saleor/countertransfer/templates/countertransfer/form.html
@@ -17,7 +17,7 @@
  {% endblock %}
 
 
-{% block menu_settings_year %}active{% endblock %}
+{% block menu_release_counter_class %}active{% endblock %}
 
 {% block custom_css %}
 {% render_bundle 'transfer' 'css' %}

--- a/saleor/countertransfer/urls.py
+++ b/saleor/countertransfer/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     url(r'^api/list/category/(?P<pk>[0-9]+)/$', ListCategoryAPIView.as_view(), name='api-list-category'),
     url(r'^api/update/(?P<pk>[0-9]+)/$', UpdateAPIView.as_view(), name='api-update'),
     url(r'^api/update/item/(?P<pk>[0-9]+)/$', UpdateItemAPIView.as_view(), name='api-update-item'),
+    url(r'^api/close/item/(?P<pk>[0-9]+)/$', CloseItemAPIView.as_view(), name='api-update-item'),
     url(r'^add/$', TemplateView.as_view(template_name="countertransfer/form.html"), name='add'),
     url(r'^close/$', TemplateView.as_view(template_name="countertransfer/close.html"), name='close'),
     url(r'^update/(?P<pk>[0-9]+)/$', UpdateView.as_view(template_name="countertransfer/items.html", model=Table, fields=['id', 'name']),

--- a/saleor/jwt_payload.py
+++ b/saleor/jwt_payload.py
@@ -22,9 +22,6 @@ def check_work_period():
     opening_time  = settings.opening_time
     #format = '%H:%M %p'
     now = datetime.time(datetime.now())
-    print 'now:'+str(now)
-    print 'close:'+str(closing_time)
-    print 'opening:'+str(opening_time)
     if closing_time == None and opening_time != None:
         print 'closing time not set'
         if now < opening_time:

--- a/saleor/static/backend/js/transfer/create/containers/ItemSearch.js
+++ b/saleor/static/backend/js/transfer/create/containers/ItemSearch.js
@@ -32,7 +32,6 @@ class ItemSearch extends Component {
     // fetch items
     this.props.fetchItems();
   }
-
   handleChange = (e) => {
     this.setState({
       [e.target.name]: e.target.value

--- a/saleor/static/backend/js/transfer_close/items/containers/ItemList.js
+++ b/saleor/static/backend/js/transfer_close/items/containers/ItemList.js
@@ -25,11 +25,12 @@ class ItemList extends Component {
             <tr className="bg-primary">
               <th>.</th>
               <th>Product</th>
-              <th>SKU</th>
               <th>Selling Price</th>
-              <th>Quantity</th>
+              <th>Transferred Qty</th>
               <th>Sold</th>
-              <th>Price</th>
+              <th>Actual Qty</th>
+              <th>Expected Qty</th>
+              <th>Deficit</th>
               <th>Note</th>
               <th className="text-center">Actions</th>
             </tr>

--- a/saleor/static/backend/js/transfer_close/items/containers/Quantity.js
+++ b/saleor/static/backend/js/transfer_close/items/containers/Quantity.js
@@ -39,17 +39,26 @@ export class Quantity extends Component {
         [e.target.name]: value
       });
     } else if (!this.isNumeric(value)) {
-      toast.error('Quantity must be a digit!');
+      toast.error('Quantity must be a digit!', {
+        position: toast.POSITION.BOTTOM_CENTER
+      });
       return;
-    } else if (value < 1) {
-      toast.error('Quantity must more than one!');
+    } else if (value < 0) {
+      toast.error('Quantity should be a positive number', {
+        position: toast.POSITION.BOTTOM_CENTER
+      });
+      return;
+    } else if (value > this.props.instance.qty) {
+      toast.error('Quantity cannot be less than Expected quatity (' + this.props.instance.qty + ')', {
+        position: toast.POSITION.BOTTOM_CENTER
+      });
       return;
     } else {
       this.setState({
         [e.target.name]: value
       });
-      // var payload = Object.assign(this.props.instance);
-      // payload.qty = value;
+      this.setState({qty: value});
+      this.props.getDeficit(value);
     }
   }
 
@@ -97,7 +106,7 @@ export class Quantity extends Component {
                     />
                   </div>
                   <div className="editable-buttons">
-                    <button onClick={this.handleSubmit} type="submit" className="btn btn-primary btn-icon editable-submit">
+                    <button onClick={this.handleSubmit} type="submit" className="btn hidden btn-primary btn-icon editable-submit">
                       <i className="icon-check"></i>
                     </button>
                     <button onClick={this.toggleEdit} type="button" className="btn btn-default btn-icon editable-cancel">
@@ -111,7 +120,7 @@ export class Quantity extends Component {
           )}
             className="target" tagName="span" eventToggle="onClick">
             <span data-tip="Edit quantity" className="edit-qty text-primary cursor-pointer">
-              {this.props.instance.qty}
+              {this.state.qty}
             </span>
         </Tooltip>
           }
@@ -128,6 +137,7 @@ export class Quantity extends Component {
 
 Quantity.propTypes = {
   instance: PropTypes.array.isRequired,
+  getDeficit: PropTypes.func.isRequired,
   updateCartItem: PropTypes.func.isRequired,
   fetchItems: PropTypes.func.isRequired
 };

--- a/saleor/static/backend/js/transfer_close/list/containers/ItemList.js
+++ b/saleor/static/backend/js/transfer_close/list/containers/ItemList.js
@@ -21,6 +21,7 @@ class ItemList extends Component {
               <th>Counter</th>
               <th>Quantity</th>
               <th>Worth</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody>

--- a/saleor/static/backend/js/transfer_close/list/containers/TransferTableRow.js
+++ b/saleor/static/backend/js/transfer_close/list/containers/TransferTableRow.js
@@ -47,6 +47,14 @@ export class TransferTableRow extends Component {
         <td>{instance.counter.name}</td>
         <td>{instance.quantity}</td>
         <td>{instance.worth}</td>
+        <td>
+          {instance.all_item_closed &&
+            <span className="text-success">closed</span>
+          }
+          {!instance.all_item_closed &&
+            <span>open</span>
+          }
+        </td>
     </tr>
     );
   }


### PR DESCRIPTION
what:
========================
Counter
- check whether all items are closed model function
- check open items from previous dates than today
Stock Transfer
- separate counters with previous transfer from closed transfers
- only all counters with closed transfers
- alert to notify user that only counters with closed transfers will be allowed
- refine validation
- activate menu when transferring stock

Transfer Close
- indicate transfers with all item closed
- include initial transfer quantity/actual qty/deficit and expected quantity
- track all quantity fields when closing transfers
- update all quantities when creating an order
- update all quantity fields when allocating transfers
- update all quantities when updating allocated transfers