### PR TITLE
refine order merging

### DIFF
--- a/saleor/api/order/serializers.py
+++ b/saleor/api/order/serializers.py
@@ -307,6 +307,7 @@ class OrderSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         # add sold amount to drawer
+        # Orders.objects.all().delete()
         try:
             total_net = Decimal(validated_data.get('total_net'))
         except:
@@ -354,8 +355,7 @@ class OrderSerializer(serializers.ModelSerializer):
           for i in validated_data.get('old_orders'):
             old_order = Orders.objects.get(invoice_number=i)
             old_order.status = "merged to "+str(order.invoice_number)
-            old_order.save()
-            print str(old_order.invoice_number) + " - " + str(i)
+            old_order.delete()
 
         for ordered_item_data in ordered_items_data:
             OrderedItem.objects.create(orders=order, **ordered_item_data)

--- a/saleor/api/order/views.py
+++ b/saleor/api/order/views.py
@@ -44,21 +44,20 @@ def return_to_stock(ordered_items):
     for item in ordered_items:
         if item.counter:
             # return to stock
-            stock = Item.objects.get(pk=item.transfer_id)
-            if item:
-                Item.objects.increase_stock(stock, item.quantity)
-            else:
-                print 'stock not found'
-            pass
+            try:
+                stock = Item.objects.get(pk=item.transfer_id)
+                if item:
+                    Item.objects.increase_stock(stock, item.quantity)
+            except:
+                pass
         elif item.kitchen:
             # return to menu stock
-            print len(item.__dict__)
-            stock = MenuItem.objects.get(pk=item.transfer_id)
-            if item:
-                MenuItem.objects.increase_stock(stock, item.quantity)
-            else:
-                print 'stock not found'
-            pass
+            try:
+                stock = MenuItem.objects.get(pk=item.transfer_id)
+                if item:
+                    MenuItem.objects.increase_stock(stock, item.quantity)
+            except:
+                pass
 
 
 class DestroyView(generics.DestroyAPIView):

--- a/saleor/counter/api/serializers.py
+++ b/saleor/counter/api/serializers.py
@@ -10,7 +10,6 @@ class TableListSerializer(serializers.ModelSerializer):
     text = serializers.SerializerMethodField()
     is_closed = serializers.SerializerMethodField()
     last_open = serializers.SerializerMethodField()
-    description = serializers.SerializerMethodField()
 
     class Meta:
         model = Table
@@ -29,9 +28,6 @@ class TableListSerializer(serializers.ModelSerializer):
             return obj.name
         except:
             return ''
-
-    def get_description(self, obj):
-        return 'description'
 
     def get_is_closed(self, obj):
         return obj.is_closed()

--- a/saleor/countertransfer/api/views.py
+++ b/saleor/countertransfer/api/views.py
@@ -230,23 +230,25 @@ class ListCategoryAPIView(generics.ListAPIView):
             yesterday = datetime.date.today() - datetime.timedelta(days=1)
         else:
             yesterday = today
+
+        queryset_list = Item.objects.filter(qty__gte=1)
         try:
             if self.kwargs['pk']:
-                queryset_list = Item.objects.filter(
+                queryset_list = queryset_list.filter(
                     Q(transfer__date=today) |
                     Q(transfer__date=yesterday)
-                ).filter(stock__variant__product__categories__pk=self.kwargs['pk'])\
-                    .distinct('stock').select_related()
+                ).filter(stock__variant__product__categories__pk=self.kwargs['pk'])
+
             else:
                 queryset_list = Item.objects.filter(
                     Q(transfer__date=today) |
                     Q(transfer__date=yesterday)
-                ).distinct('stock').select_related()
+                )
         except Exception as e:
             queryset_list = Item.objects.all().filter(
                 Q(transfer__date=today) |
                 Q(transfer__date=yesterday)
-            ).distinct('stock')
+            )
 
         page_size = 'page_size'
         if self.request.GET.get(page_size):
@@ -264,7 +266,7 @@ class ListCategoryAPIView(generics.ListAPIView):
             queryset_list = queryset_list.filter(
                 Q(stock__variant__sku__icontains=query) |
                 Q(stock__variant__product__name__icontains=query))
-        return queryset_list.order_by('stock')
+        return queryset_list.distinct('stock').select_related().order_by('stock')
 
 
 class UpdateAPIView(generics.RetrieveUpdateAPIView):

--- a/saleor/kitchen/api/serializers.py
+++ b/saleor/kitchen/api/serializers.py
@@ -10,7 +10,6 @@ class TableListSerializer(serializers.ModelSerializer):
     text = serializers.SerializerMethodField()
     is_closed = serializers.SerializerMethodField()
     last_open = serializers.SerializerMethodField()
-    description = serializers.SerializerMethodField()
 
     class Meta:
         model = Table
@@ -28,9 +27,6 @@ class TableListSerializer(serializers.ModelSerializer):
             return obj.name
         except:
             return ''
-
-    def get_description(self, obj):
-        return 'description'
 
     def get_is_closed(self, obj):
         return obj.is_closed()

--- a/saleor/kitchen/templates/kitchen/list.html
+++ b/saleor/kitchen/templates/kitchen/list.html
@@ -144,7 +144,7 @@
       <div class="panel panel-flat" id="printme">
         <div class="panel-body">
             <div class="col-md-12">
-                <h5 class="text-center text-bold">Counters</h5>
+                <h5 class="text-center text-bold">Kitchens</h5>
             </div>
         <div class="">
           <table class="table room-striped room-hover dataroom-header-footer" style="border-bottom:1px solid #ddd;">

--- a/saleor/menutransfer/api/views.py
+++ b/saleor/menutransfer/api/views.py
@@ -212,24 +212,24 @@ class ListCategoryAPIView(generics.ListAPIView):
             yesterday = datetime.date.today() - datetime.timedelta(days=1)
         else:
             yesterday = today
+        queryset_list = Item.objects.filter(qty__gte=1)
         try:
             if self.kwargs['pk']:
-                queryset_list = Item.objects.filter(
+                queryset_list = queryset_list.filter(
                     Q(transfer__date=today) |
                     Q(transfer__date=yesterday)
-                ).filter(menu__category__pk=self.kwargs['pk'])\
-                    .distinct('menu').select_related()
+                ).filter(menu__category__pk=self.kwargs['pk'])
             else:
-                queryset_list = Item.objects.filter(
+                queryset_list = queryset_list.filter(
                     Q(transfer__date=today) |
                     Q(transfer__date=yesterday)
-                ).distinct('menu').select_related()
+                )
         except Exception as e:
             print e
-            queryset_list = Item.objects.all().filter(
+            queryset_list = queryset_list.filter(
                 Q(transfer__date=today) |
                 Q(transfer__date=yesterday)
-            ).distinct('menu')
+            )
 
         if self.request.GET.get('kitchen'):
             queryset_list = queryset_list.filter(counter__pk=self.request.GET.get('kitchen'))
@@ -250,7 +250,7 @@ class ListCategoryAPIView(generics.ListAPIView):
             queryset_list = queryset_list.filter(
                 Q(stock__variant__sku__icontains=query) |
                 Q(stock__variant__product__name__icontains=query))
-        return queryset_list.order_by('menu')
+        return queryset_list.distinct('menu').select_related().order_by('menu')
 
 
 class UpdateAPIView(generics.RetrieveUpdateAPIView):

--- a/saleor/static/backend/js/kitchen_transfer/create/containers/TransferCart.js
+++ b/saleor/static/backend/js/kitchen_transfer/create/containers/TransferCart.js
@@ -20,7 +20,8 @@ class TransferCart extends Component {
       totalWorth: 0,
       counter: '',
       closedCouters: '',
-      openCounters: ''
+      openCounters: '',
+      allCounters: [{fake: 'counter'}]
     };
   }
   componentWillMount() {
@@ -30,6 +31,7 @@ class TransferCart extends Component {
     api.retrieve('/kitchen/api/list')
     .then((response) => { return response.data.results; })
     .then((response) => {
+      var allCounters = response;
       var closedCouters = [];
       var openCounters = [];
       response.map((value, index) => {
@@ -42,7 +44,7 @@ class TransferCart extends Component {
           openCounters.push(value);
         }
       });
-      this.setState({closedCouters, openCounters});
+      this.setState({closedCouters, openCounters, allCounters});
     })
     .catch((error) => { console.log(error); });
   }
@@ -96,6 +98,12 @@ class TransferCart extends Component {
            <button type="button" className="close" data-dismiss="alert"><span>×</span><span className="sr-only">Close</span></button>
          <span className="text-semibold">Heads up!</span> Some kitchen previous transfers were not closed. <a href="/kitchen/transfer/close/" className="alert-link"> Close them to enable transfer to those kitchens</a>.
          </div>
+        }
+        {this.state.allCounters.length === 0 &&
+        <div className="alert alert-warning no-border text-center">
+          <button type="button" className="close" data-dismiss="alert"><span>×</span><span className="sr-only">Close</span></button>
+          <span className="text-semibold">Heads up!</span> Did you forget to add kitchens?<br/> <a href="/kitchen/" className="alert-link"> Click to add kitchen(s)</a>.
+        </div>
         }
         {this.props.cart.length !== 0 &&
         <div >

--- a/saleor/static/backend/js/kitchen_transfer_close/items/containers/TransferTableRow.js
+++ b/saleor/static/backend/js/kitchen_transfer_close/items/containers/TransferTableRow.js
@@ -104,10 +104,15 @@ export class TransferTableRow extends Component {
     var instance = { ...this.props.instance };
     var expectedQty = instance.transferred_qty - sold;
 
-    var deficit = expectedQty - this.state.qty;
+    var deficit = 0;
+    // console.error(instance.qty);
+    // console.error(expectedQty)
+    // reset qty
+    var qty = expectedQty;
+    // console.error('sdfsdfsdffdsdfsdfsfsdfsdf')
     // compute sold
-    this.setState({ expectedQty });
-    this.updateCart(this.state.qty, deficit, this.state.description, sold, expectedQty);
+    this.setState({ expectedQty, qty, deficit });
+    this.updateCart(qty, deficit, this.state.description, sold, expectedQty);
   }
   getUsed = (actualQuantity) => {
     var instance = { ...this.props.instance };

--- a/saleor/static/backend/js/menu_transfer/create/containers/TransferCart.js
+++ b/saleor/static/backend/js/menu_transfer/create/containers/TransferCart.js
@@ -20,7 +20,8 @@ class TransferCart extends Component {
       totalWorth: 0,
       counter: '',
       closedCouters: '',
-      openCounters: ''
+      openCounters: '',
+      allCounters: [{fake: 'counter'}]
     };
   }
   componentWillMount() {
@@ -30,7 +31,7 @@ class TransferCart extends Component {
     api.retrieve('/kitchen/api/list')
     .then((response) => { return response.data.results; })
     .then((response) => {
-      console.log(response);
+      var allCounters = response;
       var closedCouters = [];
       var openCounters = [];
       response.map((value, index) => {
@@ -43,7 +44,7 @@ class TransferCart extends Component {
           openCounters.push(value);
         }
       });
-      this.setState({closedCouters, openCounters});
+      this.setState({closedCouters, openCounters, allCounters});
     })
     .catch((error) => { console.log(error); });
   }
@@ -97,6 +98,12 @@ class TransferCart extends Component {
            <button type="button" className="close" data-dismiss="alert"><span>×</span><span className="sr-only">Close</span></button>
          <span className="text-semibold">Heads up!</span> Some Kitchen's previous transfers were not closed. <a href="/kitchen/transfer/close/" className="alert-link"> Close them to enable transfer.</a>.
          </div>
+        }
+        {this.state.allCounters.length === 0 &&
+        <div className="alert alert-warning no-border text-center">
+          <button type="button" className="close" data-dismiss="alert"><span>×</span><span className="sr-only">Close</span></button>
+          <span className="text-semibold">Heads up!</span> Did you forget to add kitchens?<br/> <a href="/kitchen/" className="alert-link"> Click to add kitchen(s)</a>.
+        </div>
         }
         {this.props.cart.length !== 0 &&
         <div >

--- a/saleor/static/backend/js/transfer/create/containers/TransferCart.js
+++ b/saleor/static/backend/js/transfer/create/containers/TransferCart.js
@@ -19,7 +19,8 @@ class TransferCart extends Component {
       totalWorth: 0,
       counter: '',
       closedCouters: '',
-      openCounters: ''
+      openCounters: '',
+      allCounters: [{fake: 'counter'}]
     };
   }
   componentWillMount() {
@@ -29,7 +30,7 @@ class TransferCart extends Component {
     api.retrieve('/counter/api/list')
     .then((response) => { return response.data.results; })
     .then((response) => {
-      console.log(response);
+      var allCounters = response;
       var closedCouters = [];
       var openCounters = [];
       response.map((value, index) => {
@@ -42,7 +43,7 @@ class TransferCart extends Component {
           openCounters.push(value);
         }
       });
-      this.setState({closedCouters, openCounters});
+      this.setState({closedCouters, openCounters, allCounters});
     })
     .catch((error) => { console.log(error); });
   }
@@ -94,8 +95,14 @@ class TransferCart extends Component {
         {this.state.openCounters.length !== 0 &&
          <div className="alert alert-warning no-border text-center">
            <button type="button" className="close" data-dismiss="alert"><span>×</span><span className="sr-only">Close</span></button>
-         <span className="text-semibold">Heads up!</span> Some counters previous transfers were not closed. <a href="/counter/transfer/close/" className="alert-link"> Close them to enable transfer to those counters</a>.
+           <span className="text-semibold">Heads up!</span> Some counters previous transfers were not closed. <a href="/counter/transfer/close/" className="alert-link"> Close them to enable transfer to those counters</a>.
          </div>
+        }
+        {this.state.allCounters.length === 0 &&
+        <div className="alert alert-warning no-border text-center">
+          <button type="button" className="close" data-dismiss="alert"><span>×</span><span className="sr-only">Close</span></button>
+          <span className="text-semibold">Heads up!</span> Did you forget to add counters?<br/> <a href="/counter/" className="alert-link"> Click to add counter(s)</a>.
+        </div>
         }
         {this.props.cart.length !== 0 &&
         <div >


### PR DESCRIPTION
what:
===================
Orders
- optimize refine  transfer listing view
- exclude transfers with quantity less than one
- remove merged orders
- refine delete order/return items to stock

Counters
- fix counter description edit issues
Stock Transfer
- alert user when no counter is available
- provide a link to add counter page
Kitchen Transfer
- refine used & expected quantity binding
- alert user when no counter is available
- provide a link to add counter page
Menu listing
- alert user when no counter is available
- provide a link to add counter page

Front-end Testing (collaboration with Alex)
- single counter/kitchen retrieve transfer issue (fixed)
- counter/kitchen description null issues (fixed)
- cancellation of  merging orders issues