### PR TITLE
Feature Offline Payment

### DIFF
--- a/saleor/api/order/views.py
+++ b/saleor/api/order/views.py
@@ -295,7 +295,6 @@ class SearchOrdersListAPIView(generics.ListAPIView):
 
         query = self.request.GET.get('q')
         if query:
-            print 'query'
             queryset = queryset.filter(
                 Q(status='pending-payment') |
                 (Q(status='fully-paid') & Q(table__isnull=True) & Q(room__isnull=True)) |
@@ -381,6 +380,7 @@ class OrderUpdateAPIView(generics.RetrieveUpdateAPIView):
             terminal=terminal,
             amount=serializer.data['amount_paid'],
             trans_type='sale')
+
 
 
 def send_to_sale(credit):

--- a/saleor/dashboard/management.py
+++ b/saleor/dashboard/management.py
@@ -64,8 +64,8 @@ def add_stock_payment_options(sender, **kwargs):
         if not cash.exists():
             Payment.objects.create(name="Cash")
 
-        cash = Payment.objects.filter(name='Cheque')
-        if not cash.exists():
+        cheque = Payment.objects.filter(name='Cheque')
+        if not cheque.exists():
             Payment.objects.create(name="Cheque")
 
         visa = PaymentOption.objects.filter(name='Visa')
@@ -75,6 +75,12 @@ def add_stock_payment_options(sender, **kwargs):
         mpesa = Payment.objects.filter(name='Mpesa')
         if not mpesa.exists():
             Payment.objects.create(name="Mpesa")
+
+        mpesa_offline = Payment.objects.filter(name='Mpesa Offline')
+        if not mpesa_offline.exists():
+            Payment.objects.create(name="Mpesa Offline")
+
+
     except:
         print('Error creating payment options')
 
@@ -90,6 +96,9 @@ def add_payment_options(sender, **kwargs):
         mpesa = PaymentOption.objects.filter(name='Mpesa')
         if not mpesa.exists():
             PaymentOption.objects.create(name="Mpesa")
+        mpesa_offline = Payment.objects.filter(name='Mpesa Offline')
+        if not mpesa_offline.exists():
+            PaymentOption.objects.create(name="Mpesa Offline")
         points = PaymentOption.objects.filter(name='Loyalty Points')
         if not points.exists():
             PaymentOption.objects.create(name="Loyalty Points")

--- a/saleor/menu/templates/menu/list.html
+++ b/saleor/menu/templates/menu/list.html
@@ -45,7 +45,7 @@
        }
     }
 
-    .inner-z-index { z-index: -1; }
+    /* .inner-z-index { z-index: -1; } */
 
 </style>
  {% endblock %}

--- a/saleor/mpesa_transactions/api/serializers.py
+++ b/saleor/mpesa_transactions/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from saleor.mpesa_transactions.models import MpesaTransactions
+from decimal import Decimal
 
 Table = MpesaTransactions
 
@@ -25,6 +26,7 @@ class TableListSerializer(serializers.ModelSerializer):
             'business_short_code',
             'transaction_type',
             'status',
+            'client_status',
             'created_at',
             'created'
         )
@@ -32,3 +34,70 @@ class TableListSerializer(serializers.ModelSerializer):
     def get_created(self, obj):
         time = obj.created_at.time().strftime('%H:%M %p')
         return time
+
+
+class CreatePaymentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Table
+        fields = (
+            'id',
+            'msisdn',
+            'first_name',
+            'middle_name',
+            'last_name',
+            'trans_time',
+            'trans_id',
+            'trans_amount',
+            'org_account_balance',
+            'invoice_number',
+            'bill_ref_number',
+            'third_party_transid',
+            'business_short_code',
+            'transaction_type',
+            'status'
+        )
+
+    def validate_trans_amount(self, value):
+        data = self.get_initial()
+        try:
+            Decimal(data.get('trans_amount'))
+        except Exception as e:
+            raise serializers.ValidationError('Amount should be a decimal/integer')
+        return value
+
+    def create(self, validated_data):
+        instance = Table()
+
+        instance.first_name = validated_data.get('first_name')
+        instance.middle_name = validated_data.get('middle_name')
+        instance.last_name = validated_data.get('last_name')
+        instance.trans_id = validated_data.get('trans_id')
+        instance.trans_amount = validated_data.get('trans_amount')
+        instance.trans_time = validated_data.get('trans_time')
+        instance.msisdn = validated_data.get('msisdn')
+
+        instance.save()
+        return instance
+
+
+class DetailSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Table
+        fields = (
+            'id',
+            'msisdn',
+            'first_name',
+            'middle_name',
+            'last_name',
+            'trans_time',
+            'trans_id',
+            'trans_amount',
+            'org_account_balance',
+            'invoice_number',
+            'bill_ref_number',
+            'third_party_transid',
+            'business_short_code',
+            'transaction_type',
+            'status'
+        )

--- a/saleor/mpesa_transactions/models.py
+++ b/saleor/mpesa_transactions/models.py
@@ -49,6 +49,10 @@ class MpesaTransactions(models.Model):
         pgettext_lazy('MpesaTransactions field',
                       'status( [0 - not picked], [1 - picked], [2 -inserted to db] )'),
         default=0)
+    client_status = models.IntegerField(
+        pgettext_lazy('MpesaTransactions field',
+                      'status( [0 - not picked], [1 - picked], [2 -inserted to db] )'),
+        default=0)
 
     updated_at = models.DateTimeField(
         pgettext_lazy('MpesaTransactions field', 'date of update'),

--- a/saleor/mpesa_transactions/urls.py
+++ b/saleor/mpesa_transactions/urls.py
@@ -9,8 +9,12 @@ from .models import MpesaTransactions as Table
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name="mpesa_transactions/list.html"), name="index"),
     url(r'^api/list/$', ListAPIView.as_view(), name='api-list'),
+    url(r'^api/list/detail/$', ListSingleAPIView.as_view(), name='api-list-detail'),
+    url(r'^api/create/$', CreateAPIView.as_view(), name='api-create-mpesa-payment'),
     url(r'^add/$', TemplateView.as_view(template_name="mpesa_transactions/form.html"), name='add'),
     url(r'^update/(?P<pk>[0-9]+)/$', UpdateView.as_view(template_name="counter/form.html", model=Table, fields=['id', 'name']),
         name='update'),
+    url(r'^api/detail/(?P<pk>[0-9]+)/$', DetailAPIView.as_view(),
+        name='api-mpesa-detail'),
 ]
 

--- a/saleor/orders/models.py
+++ b/saleor/orders/models.py
@@ -184,6 +184,7 @@ class OrderedItem(models.Model):
         verbose_name=pgettext_lazy('OrderedItem field', 'Kitchen'))
     ready = models.BooleanField(default=False)
     collected = models.BooleanField(default=False)
+    cold = models.BooleanField(default=False)
     objects = OrderItemManager()
 
     class Meta:

--- a/saleor/static/backend/js/mconnect/list/containers/FilterBlock.js
+++ b/saleor/static/backend/js/mconnect/list/containers/FilterBlock.js
@@ -19,7 +19,8 @@ class FilterBlock extends Component {
     };
   }
   toggleInstanceForm = () => {
-    this.setState({open: !this.state.open});
+//    this.setState({open: !this.state.open});
+    console.log("about to open");
   }
   render() {
     const state = { ...this.state };
@@ -32,7 +33,7 @@ class FilterBlock extends Component {
               {!state.open &&
               <span className="animated fadeIn">
               <i className="icon-add position-left"></i>
-              Add menu
+              Add Mpesa Transaction
               </span>
               }
               {state.open &&

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -612,7 +612,7 @@
                            <i class="icon-typewriter"></i>Payments
                           </a>
                       </li>
-                      <li class="{% block menu_mpesa_payments %}{% endblock %}">
+                      <li class="hidden {% block menu_mpesa_payments %}{% endblock %}">
                           <a href="{% url 'mpesa_transactions:index'%}">
                            <i class="icon-typewriter"></i>Mpesa Payments
                           </a>


### PR DESCRIPTION
#### WHAT
 - create payment-transaction create api view and serializer
 - create payment-transaction detail retrieve api view and serializer
 - add the function to change the status' of the payment offlines payments 
 - add the cold boolean attribute to the OrderedItem model and in the api view and serializers - to handle the update process
 - commented the toggle functionality in the FilterBlock
 - comment the payment module in the base sidebar menu

#### WHY
 - the payment-transaction create api view is for the new payment offline payments
 - the detail retrieve api view and serializer is for the new payment offline payments
 - the change status function marks used payments not to be picked again.
 - the payment module is still in progress hence the commenting of the module in the base sidebar menu and the part of the js file