### PR TITLE
Fix Orders Update

### DIFF
--- a/saleor/api/order/serializers.py
+++ b/saleor/api/order/serializers.py
@@ -574,7 +574,9 @@ class OrderUpdateSerializer(serializers.ModelSerializer):
             ordered_items_data = validated_data.pop('ordered_items')
         except Exception as e:
             raise ValidationError('Ordered items field should not be empty')
-        # return order sold item to transfer stock then delete then
+
+        # return order sold item to transfer stock then delete them
+        # Item = CounterTransferItems
         items = instance.ordered_items.all()
         for data in items:
             if data.counter:

--- a/saleor/countertransfer/models.py
+++ b/saleor/countertransfer/models.py
@@ -395,16 +395,16 @@ class TransferItemManager(BaseUserManager):
         return total_qty
 
     def decrease_stock(self, instance, quantity):
-        instance.sold = models.F('sold') + quantity
-        instance.qty = models.F('qty') - quantity
+        instance.sold = instance.sold + quantity
+        instance.qty = instance.qty - quantity
         instance.expected_qty = instance.qty
-        instance.save(update_fields=['sold', 'qty', 'expected_qty'])
+        instance.save()
 
     def increase_stock(self, instance, quantity):
-        instance.qty = models.F('qty') + quantity
-        instance.sold = models.F('sold') - quantity
+        instance.qty = instance.qty + quantity
+        instance.sold = instance.sold - quantity
         instance.expected_qty = instance.qty
-        instance.save(update_fields=['qty', 'sold', 'expected_qty'])
+        instance.save()
 
     def instance_quantities(self, instance, filter_type='transfer', counter=None):
         if filter_type == 'transfer':
@@ -506,7 +506,7 @@ class CounterTransferItems(models.Model):
     transferred_qty = models.PositiveIntegerField(default=1,
                                                   verbose_name=pgettext_lazy('CounterTransfer field', 'transferred_qty'))
     deficit = models.IntegerField(default=0,
-                                          verbose_name=pgettext_lazy('CounterTransfer field', 'deficit'))
+                                  verbose_name=pgettext_lazy('CounterTransfer field', 'deficit'))
     expected_qty = models.PositiveIntegerField(default=1,
                                                verbose_name=pgettext_lazy('CounterTransfer field', 'expected_qty'))
 

--- a/saleor/dashboard/management.py
+++ b/saleor/dashboard/management.py
@@ -71,21 +71,13 @@ def add_stock_payment_options(sender, **kwargs):
         if not cheque.exists():
             Payment.objects.create(name="Cheque")
 
-        visa = PaymentOption.objects.filter(name='Visa')
-        if not visa.exists():
-            Payment.objects.create(name="Visa")
-
-        visa_offline = Payment.objects.filter(name='Visa Offline')
-        if not visa_offline.exists():
-            Payment.objects.create(name="Visa Offline")
-
         mpesa = Payment.objects.filter(name='Mpesa')
         if not mpesa.exists():
             Payment.objects.create(name="Mpesa")
 
-        mpesa_offline = Payment.objects.filter(name='Mpesa Offline')
-        if not mpesa_offline.exists():
-            Payment.objects.create(name="Mpesa Offline")
+        visa = Payment.objects.filter(name='Visa')
+        if not visa.exists():
+            Payment.objects.create(name="Visa")
     except Exception as e:
         logger.error("Error creating payment options", exptn=e.message)
 
@@ -100,15 +92,15 @@ def add_payment_options(sender, **kwargs):
         if not visa.exists():
             PaymentOption.objects.create(name="Visa")
 
-        visa_offline = Payment.objects.filter(name='Visa Offline')
+        visa_offline = PaymentOption.objects.filter(name='Visa Offline')
         if not visa_offline.exists():
-            Payment.objects.create(name="Visa Offline")
+            PaymentOption.objects.create(name="Visa Offline")
 
         mpesa = PaymentOption.objects.filter(name='Mpesa')
         if not mpesa.exists():
             PaymentOption.objects.create(name="Mpesa")
 
-        mpesa_offline = Payment.objects.filter(name='Mpesa Offline')
+        mpesa_offline = PaymentOption.objects.filter(name='Mpesa Offline')
         if not mpesa_offline.exists():
             PaymentOption.objects.create(name="Mpesa Offline")
 


### PR DESCRIPTION
## What
 - adjust the client visa payment options and stock visa payment options in the management.py file
 - remove the access of instance fields using the  F() helpers and used direct instance fields
 - change the save instance selected fields to save instance

## Why
 - for visa payment option offline not to appear in the stock payment options during purchase
 - the use of F() helper to access the value of the field would result to an error of postgres constraint check when saving the instance
 - saving only the selected fields would not entirely save the instance updated data

## How
 - remove the visa offline payment option in the stock payment options in the saleor/dashboard/management.py file
 - from ``instance.qty = F('qty') + quantity`` to ``instance.qty = instance.qty + quantity``
- from ``instance.save(update_fields=['sold', 'qty', 'expected_qty'])`` to ``instance.save()``
