### PR TITLE
Paginate Fixtures

### DIFF
--- a/saleor/countertransfer/api/views.py
+++ b/saleor/countertransfer/api/views.py
@@ -145,7 +145,7 @@ class ListItemsAPIView(generics.ListAPIView):
             queryset_list = queryset_list.filter(
                 Q(stock__variant__sku__icontains=query) |
                 Q(stock__variant__product__name__icontains=query))
-        return queryset_list.order_by('-id')[:5]
+        return queryset_list.order_by('-id')
 
 
 class ListStockAPIView(generics.ListAPIView):

--- a/saleor/dashboard/reports/views.py
+++ b/saleor/dashboard/reports/views.py
@@ -39,7 +39,7 @@ def sales_list(request):
         total_tax_amount = all_sales.aggregate(Sum('total_tax'))
         total_sales = []
         for sale in all_sales:
-            quantity = SoldItem.objects.filter(sales=sale).aggregate(c=Sum('quantity'))
+            quantity = SoldItem.objects.filter(sales=sale).aggregate(c=Count('sku'))
             setattr(sale, 'quantity', quantity['c'])
             total_sales.append(sale)
 
@@ -79,18 +79,6 @@ def sales_detail(request, pk=None, point=None):
         items = []
         for n in SalePoint.objects.all():
             sale_points.append(n.name)
-
-        all_sale_points = list(set(sale_points))
-
-        # for i in all_sale_points:
-        # 	sale_items = SoldItem.objects.filter(sales=sale, sale_point__name=i)
-        # 	if sale_items.exists():
-        # 		try:
-        # 			totals = sale_items.aggregate(Sum('total_cost'))['total_cost__sum']
-        # 		except:
-        # 			totals = 0
-        # 		pks = SalePoint.objects.get(name=i).pk
-        # 		items.append({'name': i, 'pk':pks, 'items': sale_items, 'amount': totals})
 
         counter_items = SoldItem.objects.filter(sales=sale, kitchen__isnull=True)
         if counter_items.exists():
@@ -299,7 +287,7 @@ def sales_search(request):
                 Q(customer__name__icontains=q) | Q(customer__mobile__icontains=q) |
                 Q(solditems__product_name__icontains=q) |
                 Q(user__email__icontains=q) |
-                Q(user__name__icontains=q)).order_by('id').distinct()
+                Q(user__name__icontains=q)).distinct()
             sales = []
 
             if request.GET.get('gid'):
@@ -385,14 +373,6 @@ def sales_search(request):
                                             {'point_pk': point_pk, 'sales': sales})
 
                 paginator = Paginator(sales, 10)
-                try:
-                    sales = paginator.page(page)
-                except PageNotAnInteger:
-                    sales = paginator.page(1)
-                except InvalidPage:
-                    sales = paginator.page(1)
-                except EmptyPage:
-                    sales = paginator.page(paginator.num_pages)
                 if p2_sz:
                     sales = paginator.page(page)
                     return TemplateResponse(request, 'dashboard/reports/sales/paginate.html',

--- a/templates/dashboard/reports/sales/p2.html
+++ b/templates/dashboard/reports/sales/p2.html
@@ -25,7 +25,7 @@
                           <th>Table/Room</th>
                           <th>Cashier</th>
                           <th class="hiddens">Payment Mode</th>
-                          <th>Quantity</th>
+                          <th>Item (s)</th>
                           <th>Total Sales (KShs)</th>
                             <th class="text-center">Total Tax (KShs)</th>
                         </tr>

--- a/templates/dashboard/reports/sales/sales_list.html
+++ b/templates/dashboard/reports/sales/sales_list.html
@@ -112,7 +112,7 @@
                           <th>Table/Room</th>
                           <th>Cashier</th>
                           <th class="hiddens">Payment Mode</th>
-                          <th>Quantity</th>
+                          <th>Item (s)</th>
                           <th>Total Sales (KShs)</th>
                             <th class="text-center">Total Tax (KShs)</th>
                         </tr>

--- a/templates/dashboard/reports/sales/search.html
+++ b/templates/dashboard/reports/sales/search.html
@@ -24,7 +24,7 @@
                           <th>Table/Room</th>
                           <th>Cashier</th>
                           <th class="hiddens">Payment Mode</th>
-                          <th>Quantity</th>
+                          <th>Item (s)</th>
                            <th>Total Sales (KShs)</th>
                             <th class="text-center">Total Tax (KShs)</th>
                         </tr>


### PR DESCRIPTION
## What
1. removed the pagination expection block to default to pagination number of 10
2. changed the quantity column to items column and fixed the displayed numbers accordingly
3. removed the 5 limitation display on transfer items which would make the pagination be fixed on 5 items display when closing stock

## Why
1. to atleast default to 10 items display
2. - the quantity column reflects the number of items of the sale hence renaming it accordingly
    - the display number on the column showed the quantity instead of the number of items so as to get the quantities in the sales detail page
3. limitation of 5 could not allow one to change the pagination size to 20 or 100 due to `[:5]` limit on the api list view for countertransfer items